### PR TITLE
Lifecycle handlers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -118,6 +118,14 @@
   version = "v2.9.1"
 
 [[projects]]
+  digest = "1:4322fcb2f4d508898c3d9b0390a2e58211b53e6d9c25230b225df9a032fe26d6"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "5858425f75500d40c52783dce87d085a483ce135"
+  version = "v4.2.0"
+
+[[projects]]
   digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -913,6 +921,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
@@ -1019,6 +1028,7 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/controller/controllerutil",
     "pkg/event",
@@ -1091,9 +1101,10 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth",
+    "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
@@ -1105,8 +1116,10 @@
     "k8s.io/kube-openapi/pkg/common",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
+    "sigs.k8s.io/controller-runtime/pkg/event",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,3 +81,7 @@ required = [
 [[constraint]]
   name = "github.com/google/go-cmp"
   version = "0.3.0"
+
+[[constraint]]
+  name = "github.com/evanphx/json-patch"
+  version = "4.2.0"

--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ kubectl apply -f ./deploy
 ## demo application
 
 https://github.com/dbrinegar/akka-java-cluster-openshift
+
+## hacking
+
+* install operator-sdk
+* start minikube
+* install the CRD
+* route pod network to macbook so operator can query akka management endpoints `sudo route -n add 172.17.0.0/16 $(minikube ip)`
+
+then loop on:
+* `operator-sdk up local`
+
+and a demo app

--- a/pkg/controller/akkacluster/akkacluster_controller_test.go
+++ b/pkg/controller/akkacluster/akkacluster_controller_test.go
@@ -1,0 +1,114 @@
+package akkacluster
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appv1alpha1 "github.com/lightbend/akka-cluster-operator/pkg/apis/app/v1alpha1"
+)
+
+func TestAkkaController(t *testing.T) {
+	name := types.NamespacedName{
+		Name:      "akka-cluster-test",
+		Namespace: "akka-cluster-namespace",
+	}
+	clusterJSON := `{
+		"apiVersion": "app.lightbend.com/v1alpha1",
+		"kind": "AkkaCluster",
+		"spec": {
+		  "replicas": 3,
+		  "template": {
+			"spec": {
+			  "containers": [
+				{
+				  "name": "main",
+				  "image": "akka-cluster:1.0.0"
+				}
+			  ]
+			}
+		  }
+		}
+	  }`
+
+	akkaCluster := &appv1alpha1.AkkaCluster{}
+	json.Unmarshal([]byte(clusterJSON), akkaCluster)
+	akkaCluster.ObjectMeta.Name = name.Name
+	akkaCluster.ObjectMeta.Namespace = name.Namespace
+
+	// mock context for reconciler
+	scheme := scheme.Scheme
+	scheme.AddKnownTypes(appv1alpha1.SchemeGroupVersion, akkaCluster)
+	client := fake.NewFakeClient(akkaCluster)
+	r := &ReconcileAkkaCluster{client: client, scheme: scheme}
+
+	// mock event loop
+	req := reconcile.Request{NamespacedName: name}
+	eventLoop := func() {
+		limit := 10
+		for ; limit > 0; limit-- {
+			res, err := r.Reconcile(req)
+			if err != nil {
+				t.Fatalf("reconcile error: %v", err)
+			}
+			if res.Requeue != true || res.RequeueAfter != 0 {
+				break
+			}
+		}
+		if limit <= 0 {
+			t.Fatalf("reconcile didn't resolve within expected number of passes")
+		}
+	}
+	eventLoop()
+
+	// check that expected resources were created
+	serviceAccount := &corev1.ServiceAccount{}
+	err := client.Get(context.TODO(), req.NamespacedName, serviceAccount)
+	if err != nil {
+		t.Error(err)
+	}
+
+	role := &rbac.Role{}
+	err = client.Get(context.TODO(), req.NamespacedName, role)
+	if err != nil {
+		t.Error(err)
+	}
+
+	rolebinding := &rbac.RoleBinding{}
+	err = client.Get(context.TODO(), req.NamespacedName, rolebinding)
+	if err != nil {
+		t.Error(err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	err = client.Get(context.TODO(), req.NamespacedName, deployment)
+	if err != nil {
+		t.Error(err)
+	}
+	if *deployment.Spec.Replicas != 3 {
+		t.Errorf("expected three replicas but got %d", deployment.Spec.Replicas)
+	}
+
+	// grow the cluster
+	*akkaCluster.Spec.Replicas = 4
+	client.Update(context.TODO(), akkaCluster)
+	eventLoop()
+
+	err = client.Get(context.TODO(), req.NamespacedName, deployment)
+	if err != nil {
+		t.Error(err)
+	}
+	if *deployment.Spec.Replicas != 4 {
+		t.Errorf("expected four replicas but got %d", deployment.Spec.Replicas)
+	}
+
+}

--- a/pkg/controller/akkacluster/debug_event_handler.go
+++ b/pkg/controller/akkacluster/debug_event_handler.go
@@ -1,0 +1,40 @@
+package akkacluster
+
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+type enqueueDebugger struct {
+}
+
+// TODO: might be more clever to use a debugger predicate on the real watch instead of these fake watches
+var elog = logf.Log.WithName("EventDebugger")
+
+func (*enqueueDebugger) Create(e event.CreateEvent, _ workqueue.RateLimitingInterface) {
+	elog.Info("Create", "uri", e.Meta.GetSelfLink())
+}
+
+// Update is called in response to an update event -  e.g. Pod Updated.
+func (*enqueueDebugger) Update(e event.UpdateEvent, _ workqueue.RateLimitingInterface) {
+	elog.Info("Update", "uir", e.MetaNew.GetSelfLink())
+	// b, _ := json.Marshal(&e)
+	// fmt.Println("Update", string(b))
+}
+
+// Delete is called in response to a delete event - e.g. Pod Deleted.
+func (*enqueueDebugger) Delete(e event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+	elog.Info("Delete", "uri", e.Meta.GetSelfLink(), "deleteStateUnknown", e.DeleteStateUnknown)
+	// b, _ := json.Marshal(&e)
+	// fmt.Println("Delete", string(b))
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request - e.g. reconcile Autoscaling, or a Webhook.
+func (*enqueueDebugger) Generic(e event.GenericEvent, _ workqueue.RateLimitingInterface) {
+	b, _ := json.Marshal(&e)
+	elog.Info("Generic", "uri", e.Meta.GetSelfLink(), "json", string(b))
+}

--- a/pkg/controller/akkacluster/deploy_builder.go
+++ b/pkg/controller/akkacluster/deploy_builder.go
@@ -18,8 +18,21 @@ type GenericResource interface {
 	runtime.Object
 }
 
-// generateResources() produces a list of rbac and deployment resources suitable for akkaCluster.
-// If akkaCluster resource does not specify needed options, we provide defaults.
+// allGeneratedResourceTypes returns list of GenericResources that might be generated in future.
+// This allows the controller to get a list of secondary resource types to watch.
+func allPossibleGeneratedResourceTypes() []GenericResource {
+	return []GenericResource{
+		&appsv1.Deployment{},
+		&rbac.RoleBinding{},
+		&rbac.Role{},
+		&corev1.ServiceAccount{},
+	}
+}
+
+// generateResources produces a list of rbac and deployment resources suitable for akkaCluster.
+// If akkaCluster resource does not specify needed options, we provide defaults. Note that these
+// objects are used as a subset reference for testing cluster object correctness, so be careful
+// not to fill in ephemeral fields here like timestamps, uuids. Return the expected reference objects.
 func generateResources(akkaCluster *appv1alpha1.AkkaCluster) []GenericResource {
 	resources := []GenericResource{}
 

--- a/pkg/controller/akkacluster/subset.go
+++ b/pkg/controller/akkacluster/subset.go
@@ -1,0 +1,132 @@
+package akkacluster
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Problem statement: we have a baseline Kubernetes resource, and a live resource, and need
+// to decide if they are out of sync, meaning the live resource doesn't match our baseline.
+// The live resource has timestamps, uids, and other downstream ephemera that we want to ignore
+// for purposes of deciding "is the live resource the same as the baseline?" We want the subset.
+//
+// Alternative approach to this problem is to convert objects to JSON--getting their exported
+// and normalized form--and compare those. A challenge with that approach is dealing with
+// default values which may be hard to detect once converted, like time.Time.
+
+// SubsetEqual (A,B) returns true if A is a subset of B.
+// This allows us to focus on a smaller set of required fields and ignore other fields
+// that have downstream mutations to objects like creationTimestamp, uid, resourceVersion.
+// The algorithm here is similar to reflect.DeepCopy, in that we use reflection to walk
+// a potentially recursive tree. For comparison, we ignore empty or zero value fields in A.
+func SubsetEqual(subset, superset interface{}) bool {
+	if subset == nil {
+		return true
+	}
+	if subset != nil && superset == nil {
+		return false
+	}
+
+	t := newTreeWalk()
+	return t.subsetValueEqual(reflect.ValueOf(subset), reflect.ValueOf(superset))
+}
+
+type treeWalk struct {
+	matches int
+	visited map[node]bool
+}
+
+func newTreeWalk() *treeWalk {
+	t := treeWalk{}
+	t.visited = make(map[node]bool)
+	return &t
+}
+
+// track visited nodes to short circuit recursion
+type node struct {
+	a1  unsafe.Pointer
+	a2  unsafe.Pointer
+	typ reflect.Type
+}
+
+// Tests for subset equality using reflected types.
+func (t *treeWalk) subsetValueEqual(subset, superset reflect.Value) bool {
+	// if subset side is undefined, then nothing to compare
+	if !subset.IsValid() {
+		return true
+	}
+
+	// sanity check, rest of code assume same type on both sides
+	if !superset.IsValid() {
+		return false
+	}
+	if subset.Type() != superset.Type() {
+		return false
+	}
+
+	// short circuit references already seen
+	isRef := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Interface:
+			return true
+		}
+		return false
+	}
+	if subset.CanAddr() && superset.CanAddr() && isRef(subset.Kind()) {
+		n := node{
+			unsafe.Pointer(subset.UnsafeAddr()),
+			unsafe.Pointer(superset.UnsafeAddr()),
+			subset.Type(),
+		}
+		if t.visited[n] {
+			return true
+		}
+		t.visited[n] = true
+	}
+
+	// walk tree
+	switch subset.Kind() {
+	case reflect.Array, reflect.Slice:
+		// recursive subset: superset may have extra elements at the end, only the subset members must match
+		if superset.Len() < subset.Len() {
+			return false
+		}
+		for i := 0; i < subset.Len(); i++ {
+			if !t.subsetValueEqual(subset.Index(i), superset.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface, reflect.Ptr:
+		return t.subsetValueEqual(subset.Elem(), superset.Elem())
+	case reflect.Struct:
+		for i, n := 0, subset.NumField(); i < n; i++ {
+			if !t.subsetValueEqual(subset.Field(i), superset.Field(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		for _, k := range subset.MapKeys() {
+			if !t.subsetValueEqual(subset.MapIndex(k), superset.MapIndex(k)) {
+				return false
+			}
+		}
+		return true
+	default:
+		// Leaf node: if exported, non-default value, compare subset with superset.
+		if subset.CanInterface() {
+			// Ignore default values, like empty string, bool false, zero int... :-|
+			// If needed, could be more selective in the kinds of zeros ignored.
+			if subset.Interface() == reflect.Zero(subset.Type()).Interface() {
+				return true
+			}
+			if subset.Interface() == superset.Interface() {
+				t.matches++
+				return true
+			}
+			return false
+		}
+		return true // Ignore non-exported opaque internal fields, like time.Time{}.
+	}
+}

--- a/pkg/controller/akkacluster/subset.go
+++ b/pkg/controller/akkacluster/subset.go
@@ -20,13 +20,6 @@ import (
 // The algorithm here is similar to reflect.DeepCopy, in that we use reflection to walk
 // a potentially recursive tree. For comparison, we ignore empty or zero value fields in A.
 func SubsetEqual(subset, superset interface{}) bool {
-	if subset == nil {
-		return true
-	}
-	if subset != nil && superset == nil {
-		return false
-	}
-
 	t := newTreeWalk()
 	return t.subsetValueEqual(reflect.ValueOf(subset), reflect.ValueOf(superset))
 }

--- a/pkg/controller/akkacluster/subset_test.go
+++ b/pkg/controller/akkacluster/subset_test.go
@@ -1,0 +1,182 @@
+package akkacluster
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"reflect"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// whitebox tests: A<=B, A<=A, B!<=A, B<=B
+func test(a, b interface{}, t *testing.T) {
+	t.Helper() // log test messages from caller instead of this helper function
+	if !SubsetEqual(a, b) {
+		t.Error("expecting subset, but found none", a)
+	}
+	if SubsetEqual(b, a) {
+		t.Error("expected no subset, but found one", b)
+	}
+	if !SubsetEqual(a, a) {
+		t.Error("expecting subset of self to be true, but found false", a)
+	}
+	if !SubsetEqual(b, b) {
+		t.Error("expecting subset of self to be true, but found false", b)
+	}
+}
+
+// blackbox tests: verify matching node count
+func testMatchCount(a, b interface{}, expectedMatchCount int, t *testing.T) {
+	t.Helper()
+	// mirror inner workings of SubsetEqual so we can inspect the treeWalk metadata
+	tree := newTreeWalk()
+	if a == nil && expectedMatchCount != 0 {
+		t.Fatalf("should expect no matches on nil subset, but wanted %d", expectedMatchCount)
+	}
+	if a != nil && b == nil && expectedMatchCount != 0 {
+		t.Fatalf("should expect no matches against nil superset, but wanted %d", expectedMatchCount)
+	}
+
+	// A <= B
+	if !tree.subsetValueEqual(reflect.ValueOf(a), reflect.ValueOf(b)) {
+		t.Error("expecting subset, but found none", a)
+	}
+	if expectedMatchCount != tree.matches {
+		t.Errorf("expecting %d matches, but got %d", expectedMatchCount, tree.matches)
+	}
+
+	// A <= A
+	tree = newTreeWalk()
+	if !tree.subsetValueEqual(reflect.ValueOf(a), reflect.ValueOf(a)) {
+		t.Error("expecting subset of self, but found none", a)
+	}
+	if expectedMatchCount != tree.matches {
+		t.Errorf("expecting %d matches against self, but got %d", expectedMatchCount, tree.matches)
+	}
+}
+
+func testN(a, b interface{}, expectedMatches int, t *testing.T) {
+	t.Helper()
+	test(a, b, t)
+	testMatchCount(a, b, expectedMatches, t)
+}
+
+func test0(a, b interface{}, t *testing.T) {
+	t.Helper()
+	testN(a, b, 0, t)
+}
+
+func test1(a, b interface{}, t *testing.T) {
+	t.Helper()
+	testN(a, b, 1, t)
+}
+
+func TestSubsetDeployment(t *testing.T) {
+	deploymentSuperset, err := ioutil.ReadFile("testsubset/deployment_superset.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deploymentSubset, err := ioutil.ReadFile("testsubset/deployment_subset.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subset := &appsv1.Deployment{}
+	superset := &appsv1.Deployment{}
+	if err := json.Unmarshal(deploymentSubset, subset); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(deploymentSuperset, superset); err != nil {
+		t.Fatal(err)
+	}
+	testN(subset, superset, 30, t)
+}
+
+func TestSubsetBasics(t *testing.T) {
+	type p struct {
+		Bool bool
+		Code []byte
+		Map  map[string]int
+	}
+
+	type f struct {
+		Name       string
+		Age        uint
+		Percentage float64
+		Timestamp  time.Time
+		Nested     *p
+	}
+	superset := &f{
+		Name:       "ohai",
+		Age:        6,
+		Percentage: 0.99,
+		Timestamp:  time.Unix(1557787336, 1),
+		Nested: &p{
+			Bool: true,
+			Code: []byte{'a', 'b', 'c'},
+			Map:  map[string]int{"a": 1, "b": 2, "c": 3},
+		},
+	}
+	var empty interface{}
+
+	test0(nil, superset, t)
+	test0(empty, superset, t)
+	test0(&f{Timestamp: superset.Timestamp}, superset, t) // time.Time is opaque
+
+	test1(&f{Name: superset.Name}, superset, t)
+	test1(&f{Age: superset.Age}, superset, t)
+	test1(&f{Percentage: superset.Percentage}, superset, t)
+	test1(&f{Nested: &p{Bool: superset.Nested.Bool}}, superset, t)
+	test1(&f{Nested: &p{Code: []byte{superset.Nested.Code[0]}}}, superset, t)
+	test1(&f{Nested: &p{Map: map[string]int{"b": 2}}}, superset, t)
+
+	testN(&f{Nested: &p{Code: superset.Nested.Code}}, superset, len(superset.Nested.Code), t)
+
+	// invalid comparisons
+	if SubsetEqual(&f{Name: "onoe"}, nil) {
+		t.Error("expecting subset test to fail because nil superset")
+	}
+	if SubsetEqual(&f{Name: "onoe"}, "onoe") {
+		t.Error("expecting subset test to fail because mismatched types")
+	}
+	if SubsetEqual(&f{Nested: &p{Bool: superset.Nested.Bool}}, &f{Nested: nil}) {
+		t.Error("expecting subset test to fail because superset invalid")
+	}
+
+	// deeper mismatch
+	if SubsetEqual(&f{Nested: &p{Code: []byte{'x'}}}, superset) {
+		t.Error("expecting subset test to fail because slice mismatch")
+	}
+	if SubsetEqual(&f{Nested: &p{Map: map[string]int{"b": 1}}}, superset) {
+		t.Error("expecting subset test to fail because map mismatch", superset.Nested.Map)
+	}
+
+	// recursive subset: embedded containers are themselves subsets
+	// using json serde to get a deep copy of superset, so everything matches except one thing
+	copy, _ := json.Marshal(superset)
+	subset := &f{}
+	json.Unmarshal(copy, subset)
+	subset.Nested.Code = []byte{'a', 'b'}
+	testN(subset, superset, 9, t)
+
+	json.Unmarshal(copy, subset)
+	subset.Nested.Map = map[string]int{"b": 2, "c": 3}
+	testN(subset, superset, 9, t)
+}
+
+func TestSubsetShortCircuit(t *testing.T) {
+	type recursive struct {
+		Name     string
+		Extra    bool
+		Infinity *recursive
+	}
+	subset := &recursive{"ohai", false, nil}
+	subset.Infinity = subset
+	superset := &recursive{"ohai", true, nil}
+	superset.Infinity = superset
+
+	// without effective short circuit, this will overflow stack or timeout
+	testN(subset, superset, 2, t)
+}

--- a/pkg/controller/akkacluster/testsubset/deployment_subset.json
+++ b/pkg/controller/akkacluster/testsubset/deployment_subset.json
@@ -1,0 +1,79 @@
+{
+    "metadata": {
+        "creationTimestamp": null,
+        "name": "akka-cluster-demo",
+        "namespace": "default"
+    },
+    "spec": {
+        "replicas": 3,
+        "selector": {
+            "matchLabels": {
+                "app": "akka-cluster-demo"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": 1,
+                "maxUnavailable": 0
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "akka-cluster-demo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME",
+                                "value": "akka-cluster-demo"
+                            }
+                        ],
+                        "image": "lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.0.2",
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/alive",
+                                "port": "management"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10
+                        },
+                        "name": "main",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http"
+                            },
+                            {
+                                "containerPort": 2552,
+                                "name": "remoting"
+                            },
+                            {
+                                "containerPort": 8558,
+                                "name": "management"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/ready",
+                                "port": "management"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10
+                        },
+                        "resources": {}
+                    }
+                ],
+                "serviceAccountName": "akka-cluster-demo"
+            }
+        }
+    },
+    "status": {}
+}

--- a/pkg/controller/akkacluster/testsubset/deployment_superset.json
+++ b/pkg/controller/akkacluster/testsubset/deployment_superset.json
@@ -1,0 +1,142 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2019-05-11T02:52:00Z",
+        "generation": 1,
+        "name": "akka-cluster-demo",
+        "namespace": "default",
+        "ownerReferences": [
+            {
+                "blockOwnerDeletion": true,
+                "apiVersion": "app.lightbend.com/v1alpha1",
+                "kind": "AkkaCluster",
+                "name": "akka-cluster-demo",
+                "uid": "bfaaeaeb-7397-11e9-9db1-080027f95557",
+                "controller": true
+            }
+        ],
+        "resourceVersion": "250283",
+        "selfLink": "/apis/apps/v1/namespaces/default/deployments/akka-cluster-demo",
+        "uid": "bfe3aa28-7397-11e9-9db1-080027f95557"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "akka-cluster-demo"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": 1,
+                "maxUnavailable": 0
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "akka-cluster-demo"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "AKKA_CLUSTER_BOOTSTRAP_SERVICE_NAME",
+                                "value": "akka-cluster-demo"
+                            }
+                        ],
+                        "image": "lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.0.2",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/alive",
+                                "port": "management",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "main",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 2552,
+                                "name": "remoting",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 8558,
+                                "name": "management",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "path": "/ready",
+                                "port": "management",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 20,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "akka-cluster-demo",
+                "serviceAccountName": "akka-cluster-demo",
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastUpdateTime": "2019-05-11T02:52:26Z",
+                "lastTransitionTime": "2019-05-11T02:52:26Z",
+                "reason": "MinimumReplicasAvailable",
+                "message": "Deployment has minimum availability."
+            },
+            {
+                "message": "ReplicaSet \"akka-cluster-demo-5ccf8ff7db\" has successfully progressed.",
+                "type": "Progressing",
+                "status": "True",
+                "lastUpdateTime": "2019-05-11T02:52:26Z",
+                "lastTransitionTime": "2019-05-11T02:52:00Z",
+                "reason": "NewReplicaSetAvailable"
+            }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 3,
+        "replicas": 3,
+        "updatedReplicas": 3
+    }
+}

--- a/vendor/github.com/evanphx/json-patch/LICENSE
+++ b/vendor/github.com/evanphx/json-patch/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/evanphx/json-patch/cmd/json-patch/file_flag.go
+++ b/vendor/github.com/evanphx/json-patch/cmd/json-patch/file_flag.go
@@ -1,0 +1,39 @@
+package main
+
+// Borrowed from Concourse: https://github.com/concourse/atc/blob/master/atccmd/file_flag.go
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileFlag is a flag for passing a path to a file on disk. The file is
+// expected to be a file, not a directory, that actually exists.
+type FileFlag string
+
+// UnmarshalFlag implements go-flag's Unmarshaler interface
+func (f *FileFlag) UnmarshalFlag(value string) error {
+	stat, err := os.Stat(value)
+	if err != nil {
+		return err
+	}
+
+	if stat.IsDir() {
+		return fmt.Errorf("path '%s' is a directory, not a file", value)
+	}
+
+	abs, err := filepath.Abs(value)
+	if err != nil {
+		return err
+	}
+
+	*f = FileFlag(abs)
+
+	return nil
+}
+
+// Path is the path to the file
+func (f FileFlag) Path() string {
+	return string(f)
+}

--- a/vendor/github.com/evanphx/json-patch/cmd/json-patch/main.go
+++ b/vendor/github.com/evanphx/json-patch/cmd/json-patch/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type opts struct {
+	PatchFilePaths []FileFlag `long:"patch-file" short:"p" value-name:"PATH" description:"Path to file with one or more operations"`
+}
+
+func main() {
+	var o opts
+	_, err := flags.Parse(&o)
+	if err != nil {
+		log.Fatalf("error: %s\n", err)
+	}
+
+	patches := make([]jsonpatch.Patch, len(o.PatchFilePaths))
+
+	for i, patchFilePath := range o.PatchFilePaths {
+		var bs []byte
+		bs, err = ioutil.ReadFile(patchFilePath.Path())
+		if err != nil {
+			log.Fatalf("error reading patch file: %s", err)
+		}
+
+		var patch jsonpatch.Patch
+		patch, err = jsonpatch.DecodePatch(bs)
+		if err != nil {
+			log.Fatalf("error decoding patch file: %s", err)
+		}
+
+		patches[i] = patch
+	}
+
+	doc, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("error reading from stdin: %s", err)
+	}
+
+	mdoc := doc
+	for _, patch := range patches {
+		mdoc, err = patch.Apply(mdoc)
+		if err != nil {
+			log.Fatalf("error applying patch: %s", err)
+		}
+	}
+
+	fmt.Printf("%s", mdoc)
+}

--- a/vendor/github.com/evanphx/json-patch/errors.go
+++ b/vendor/github.com/evanphx/json-patch/errors.go
@@ -1,0 +1,38 @@
+package jsonpatch
+
+import "fmt"
+
+// AccumulatedCopySizeError is an error type returned when the accumulated size
+// increase caused by copy operations in a patch operation has exceeded the
+// limit.
+type AccumulatedCopySizeError struct {
+	limit       int64
+	accumulated int64
+}
+
+// NewAccumulatedCopySizeError returns an AccumulatedCopySizeError.
+func NewAccumulatedCopySizeError(l, a int64) *AccumulatedCopySizeError {
+	return &AccumulatedCopySizeError{limit: l, accumulated: a}
+}
+
+// Error implements the error interface.
+func (a *AccumulatedCopySizeError) Error() string {
+	return fmt.Sprintf("Unable to complete the copy, the accumulated size increase of copy is %d, exceeding the limit %d", a.accumulated, a.limit)
+}
+
+// ArraySizeError is an error type returned when the array size has exceeded
+// the limit.
+type ArraySizeError struct {
+	limit int
+	size  int
+}
+
+// NewArraySizeError returns an ArraySizeError.
+func NewArraySizeError(l, s int) *ArraySizeError {
+	return &ArraySizeError{limit: l, size: s}
+}
+
+// Error implements the error interface.
+func (a *ArraySizeError) Error() string {
+	return fmt.Sprintf("Unable to create array of size %d, limit is %d", a.size, a.limit)
+}

--- a/vendor/github.com/evanphx/json-patch/merge.go
+++ b/vendor/github.com/evanphx/json-patch/merge.go
@@ -1,0 +1,383 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
+	curDoc, err := cur.intoDoc()
+
+	if err != nil {
+		pruneNulls(patch)
+		return patch
+	}
+
+	patchDoc, err := patch.intoDoc()
+
+	if err != nil {
+		return patch
+	}
+
+	mergeDocs(curDoc, patchDoc, mergeMerge)
+
+	return cur
+}
+
+func mergeDocs(doc, patch *partialDoc, mergeMerge bool) {
+	for k, v := range *patch {
+		if v == nil {
+			if mergeMerge {
+				(*doc)[k] = nil
+			} else {
+				delete(*doc, k)
+			}
+		} else {
+			cur, ok := (*doc)[k]
+
+			if !ok || cur == nil {
+				pruneNulls(v)
+				(*doc)[k] = v
+			} else {
+				(*doc)[k] = merge(cur, v, mergeMerge)
+			}
+		}
+	}
+}
+
+func pruneNulls(n *lazyNode) {
+	sub, err := n.intoDoc()
+
+	if err == nil {
+		pruneDocNulls(sub)
+	} else {
+		ary, err := n.intoAry()
+
+		if err == nil {
+			pruneAryNulls(ary)
+		}
+	}
+}
+
+func pruneDocNulls(doc *partialDoc) *partialDoc {
+	for k, v := range *doc {
+		if v == nil {
+			delete(*doc, k)
+		} else {
+			pruneNulls(v)
+		}
+	}
+
+	return doc
+}
+
+func pruneAryNulls(ary *partialArray) *partialArray {
+	newAry := []*lazyNode{}
+
+	for _, v := range *ary {
+		if v != nil {
+			pruneNulls(v)
+			newAry = append(newAry, v)
+		}
+	}
+
+	*ary = newAry
+
+	return ary
+}
+
+var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
+var errBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
+var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
+
+// MergeMergePatches merges two merge patches together, such that
+// applying this resulting merged merge patch to a document yields the same
+// as merging each merge patch to the document in succession.
+func MergeMergePatches(patch1Data, patch2Data []byte) ([]byte, error) {
+	return doMergePatch(patch1Data, patch2Data, true)
+}
+
+// MergePatch merges the patchData into the docData.
+func MergePatch(docData, patchData []byte) ([]byte, error) {
+	return doMergePatch(docData, patchData, false)
+}
+
+func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
+	doc := &partialDoc{}
+
+	docErr := json.Unmarshal(docData, doc)
+
+	patch := &partialDoc{}
+
+	patchErr := json.Unmarshal(patchData, patch)
+
+	if _, ok := docErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONDoc
+	}
+
+	if _, ok := patchErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr == nil && *doc == nil {
+		return nil, errBadJSONDoc
+	}
+
+	if patchErr == nil && *patch == nil {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr != nil || patchErr != nil {
+		// Not an error, just not a doc, so we turn straight into the patch
+		if patchErr == nil {
+			if mergeMerge {
+				doc = patch
+			} else {
+				doc = pruneDocNulls(patch)
+			}
+		} else {
+			patchAry := &partialArray{}
+			patchErr = json.Unmarshal(patchData, patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			pruneAryNulls(patchAry)
+
+			out, patchErr := json.Marshal(patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			return out, nil
+		}
+	} else {
+		mergeDocs(doc, patch, mergeMerge)
+	}
+
+	return json.Marshal(doc)
+}
+
+// resemblesJSONArray indicates whether the byte-slice "appears" to be
+// a JSON array or not.
+// False-positives are possible, as this function does not check the internal
+// structure of the array. It only checks that the outer syntax is present and
+// correct.
+func resemblesJSONArray(input []byte) bool {
+	input = bytes.TrimSpace(input)
+
+	hasPrefix := bytes.HasPrefix(input, []byte("["))
+	hasSuffix := bytes.HasSuffix(input, []byte("]"))
+
+	return hasPrefix && hasSuffix
+}
+
+// CreateMergePatch will return a merge patch document capable of converting
+// the original document(s) to the modified document(s).
+// The parameters can be bytes of either two JSON Documents, or two arrays of
+// JSON documents.
+// The merge patch returned follows the specification defined at http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
+func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalResemblesArray := resemblesJSONArray(originalJSON)
+	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)
+
+	// Do both byte-slices seem like JSON arrays?
+	if originalResemblesArray && modifiedResemblesArray {
+		return createArrayMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// Are both byte-slices are not arrays? Then they are likely JSON objects...
+	if !originalResemblesArray && !modifiedResemblesArray {
+		return createObjectMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// None of the above? Then return an error because of mismatched types.
+	return nil, errBadMergeTypes
+}
+
+// createObjectMergePatch will return a merge-patch document capable of
+// converting the original document to the modified document.
+func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDoc := map[string]interface{}{}
+	modifiedDoc := map[string]interface{}{}
+
+	err := json.Unmarshal(originalJSON, &originalDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	dest, err := getDiff(originalDoc, modifiedDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(dest)
+}
+
+// createArrayMergePatch will return an array of merge-patch documents capable
+// of converting the original document to the modified document for each
+// pair of JSON documents provided in the arrays.
+// Arrays of mismatched sizes will result in an error.
+func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDocs := []json.RawMessage{}
+	modifiedDocs := []json.RawMessage{}
+
+	err := json.Unmarshal(originalJSON, &originalDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	total := len(originalDocs)
+	if len(modifiedDocs) != total {
+		return nil, errBadJSONDoc
+	}
+
+	result := []json.RawMessage{}
+	for i := 0; i < len(originalDocs); i++ {
+		original := originalDocs[i]
+		modified := modifiedDocs[i]
+
+		patch, err := createObjectMergePatch(original, modified)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, json.RawMessage(patch))
+	}
+
+	return json.Marshal(result)
+}
+
+// Returns true if the array matches (must be json types).
+// As is idiomatic for go, an empty array is not the same as a nil array.
+func matchesArray(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	for i := range a {
+		if !matchesValue(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt := bv.(string)
+		if bt == at {
+			return true
+		}
+	case float64:
+		bt := bv.(float64)
+		if bt == at {
+			return true
+		}
+	case bool:
+		bt := bv.(bool)
+		if bt == at {
+			return true
+		}
+	case nil:
+		// Both nil, fine.
+		return true
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		return matchesArray(at, bt)
+	}
+	return false
+}
+
+// getDiff returns the (recursive) difference between a and b as a map[string]interface{}.
+func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
+	into := map[string]interface{}{}
+	for key, bv := range b {
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			into[key] = bv
+			continue
+		}
+		// If types have changed, replace completely
+		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+			into[key] = bv
+			continue
+		}
+		// Types are the same, compare values
+		switch at := av.(type) {
+		case map[string]interface{}:
+			bt := bv.(map[string]interface{})
+			dst := make(map[string]interface{}, len(bt))
+			dst, err := getDiff(at, bt)
+			if err != nil {
+				return nil, err
+			}
+			if len(dst) > 0 {
+				into[key] = dst
+			}
+		case string, float64, bool:
+			if !matchesValue(av, bv) {
+				into[key] = bv
+			}
+		case []interface{}:
+			bt := bv.([]interface{})
+			if !matchesArray(at, bt) {
+				into[key] = bv
+			}
+		case nil:
+			switch bv.(type) {
+			case nil:
+				// Both nil, fine.
+			default:
+				into[key] = bv
+			}
+		default:
+			panic(fmt.Sprintf("Unknown type:%T in key %s", av, key))
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			into[key] = nil
+		}
+	}
+	return into, nil
+}

--- a/vendor/github.com/evanphx/json-patch/patch.go
+++ b/vendor/github.com/evanphx/json-patch/patch.go
@@ -1,0 +1,696 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	eRaw = iota
+	eDoc
+	eAry
+)
+
+var (
+	// SupportNegativeIndices decides whether to support non-standard practice of
+	// allowing negative indices to mean indices starting at the end of an array.
+	// Default to true.
+	SupportNegativeIndices bool = true
+	// AccumulatedCopySizeLimit limits the total size increase in bytes caused by
+	// "copy" operations in a patch.
+	AccumulatedCopySizeLimit int64 = 0
+)
+
+type lazyNode struct {
+	raw   *json.RawMessage
+	doc   partialDoc
+	ary   partialArray
+	which int
+}
+
+type operation map[string]*json.RawMessage
+
+// Patch is an ordered collection of operations.
+type Patch []operation
+
+type partialDoc map[string]*lazyNode
+type partialArray []*lazyNode
+
+type container interface {
+	get(key string) (*lazyNode, error)
+	set(key string, val *lazyNode) error
+	add(key string, val *lazyNode) error
+	remove(key string) error
+}
+
+func newLazyNode(raw *json.RawMessage) *lazyNode {
+	return &lazyNode{raw: raw, doc: nil, ary: nil, which: eRaw}
+}
+
+func (n *lazyNode) MarshalJSON() ([]byte, error) {
+	switch n.which {
+	case eRaw:
+		return json.Marshal(n.raw)
+	case eDoc:
+		return json.Marshal(n.doc)
+	case eAry:
+		return json.Marshal(n.ary)
+	default:
+		return nil, fmt.Errorf("Unknown type")
+	}
+}
+
+func (n *lazyNode) UnmarshalJSON(data []byte) error {
+	dest := make(json.RawMessage, len(data))
+	copy(dest, data)
+	n.raw = &dest
+	n.which = eRaw
+	return nil
+}
+
+func deepCopy(src *lazyNode) (*lazyNode, int, error) {
+	if src == nil {
+		return nil, 0, nil
+	}
+	a, err := src.MarshalJSON()
+	if err != nil {
+		return nil, 0, err
+	}
+	sz := len(a)
+	ra := make(json.RawMessage, sz)
+	copy(ra, a)
+	return newLazyNode(&ra), sz, nil
+}
+
+func (n *lazyNode) intoDoc() (*partialDoc, error) {
+	if n.which == eDoc {
+		return &n.doc, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial document")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eDoc
+	return &n.doc, nil
+}
+
+func (n *lazyNode) intoAry() (*partialArray, error) {
+	if n.which == eAry {
+		return &n.ary, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial array")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eAry
+	return &n.ary, nil
+}
+
+func (n *lazyNode) compact() []byte {
+	buf := &bytes.Buffer{}
+
+	if n.raw == nil {
+		return nil
+	}
+
+	err := json.Compact(buf, *n.raw)
+
+	if err != nil {
+		return *n.raw
+	}
+
+	return buf.Bytes()
+}
+
+func (n *lazyNode) tryDoc() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eDoc
+	return true
+}
+
+func (n *lazyNode) tryAry() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eAry
+	return true
+}
+
+func (n *lazyNode) equal(o *lazyNode) bool {
+	if n.which == eRaw {
+		if !n.tryDoc() && !n.tryAry() {
+			if o.which != eRaw {
+				return false
+			}
+
+			return bytes.Equal(n.compact(), o.compact())
+		}
+	}
+
+	if n.which == eDoc {
+		if o.which == eRaw {
+			if !o.tryDoc() {
+				return false
+			}
+		}
+
+		if o.which != eDoc {
+			return false
+		}
+
+		for k, v := range n.doc {
+			ov, ok := o.doc[k]
+
+			if !ok {
+				return false
+			}
+
+			if v == nil && ov == nil {
+				continue
+			}
+
+			if !v.equal(ov) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if o.which != eAry && !o.tryAry() {
+		return false
+	}
+
+	if len(n.ary) != len(o.ary) {
+		return false
+	}
+
+	for idx, val := range n.ary {
+		if !val.equal(o.ary[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (o operation) kind() string {
+	if obj, ok := o["op"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) path() string {
+	if obj, ok := o["path"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) from() string {
+	if obj, ok := o["from"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) value() *lazyNode {
+	if obj, ok := o["value"]; ok {
+		return newLazyNode(obj)
+	}
+
+	return nil
+}
+
+func isArray(buf []byte) bool {
+Loop:
+	for _, c := range buf {
+		switch c {
+		case ' ':
+		case '\n':
+		case '\t':
+			continue
+		case '[':
+			return true
+		default:
+			break Loop
+		}
+	}
+
+	return false
+}
+
+func findObject(pd *container, path string) (container, string) {
+	doc := *pd
+
+	split := strings.Split(path, "/")
+
+	if len(split) < 2 {
+		return nil, ""
+	}
+
+	parts := split[1 : len(split)-1]
+
+	key := split[len(split)-1]
+
+	var err error
+
+	for _, part := range parts {
+
+		next, ok := doc.get(decodePatchKey(part))
+
+		if next == nil || ok != nil {
+			return nil, ""
+		}
+
+		if isArray(*next.raw) {
+			doc, err = next.intoAry()
+
+			if err != nil {
+				return nil, ""
+			}
+		} else {
+			doc, err = next.intoDoc()
+
+			if err != nil {
+				return nil, ""
+			}
+		}
+	}
+
+	return doc, decodePatchKey(key)
+}
+
+func (d *partialDoc) set(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) add(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) get(key string) (*lazyNode, error) {
+	return (*d)[key], nil
+}
+
+func (d *partialDoc) remove(key string) error {
+	_, ok := (*d)[key]
+	if !ok {
+		return fmt.Errorf("Unable to remove nonexistent key: %s", key)
+	}
+
+	delete(*d, key)
+	return nil
+}
+
+// set should only be used to implement the "replace" operation, so "key" must
+// be an already existing index in "d".
+func (d *partialArray) set(key string, val *lazyNode) error {
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+	(*d)[idx] = val
+	return nil
+}
+
+func (d *partialArray) add(key string, val *lazyNode) error {
+	if key == "-" {
+		*d = append(*d, val)
+		return nil
+	}
+
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	sz := len(*d) + 1
+
+	ary := make([]*lazyNode, sz)
+
+	cur := *d
+
+	if idx >= len(ary) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(ary) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(ary)
+		}
+	}
+
+	copy(ary[0:idx], cur[0:idx])
+	ary[idx] = val
+	copy(ary[idx+1:], cur[idx:])
+
+	*d = ary
+	return nil
+}
+
+func (d *partialArray) get(key string) (*lazyNode, error) {
+	idx, err := strconv.Atoi(key)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if idx >= len(*d) {
+		return nil, fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	return (*d)[idx], nil
+}
+
+func (d *partialArray) remove(key string) error {
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	cur := *d
+
+	if idx >= len(cur) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(cur) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(cur)
+		}
+	}
+
+	ary := make([]*lazyNode, len(cur)-1)
+
+	copy(ary[0:idx], cur[0:idx])
+	copy(ary[idx:], cur[idx+1:])
+
+	*d = ary
+	return nil
+
+}
+
+func (p Patch) add(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.add(key, op.value())
+}
+
+func (p Patch) remove(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.remove(key)
+}
+
+func (p Patch) replace(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
+	}
+
+	_, ok := con.get(key)
+	if ok != nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
+	}
+
+	return con.set(key, op.value())
+}
+
+func (p Patch) move(doc *container, op operation) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	err = con.remove(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	return con.add(key, val)
+}
+
+func (p Patch) test(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch test operation does not apply: is missing path: %s", path)
+	}
+
+	val, err := con.get(key)
+
+	if err != nil {
+		return err
+	}
+
+	if val == nil {
+		if op.value().raw == nil {
+			return nil
+		}
+		return fmt.Errorf("Testing value %s failed", path)
+	} else if op.value() == nil {
+		return fmt.Errorf("Testing value %s failed", path)
+	}
+
+	if val.equal(op.value()) {
+		return nil
+	}
+
+	return fmt.Errorf("Testing value %s failed", path)
+}
+
+func (p Patch) copy(doc *container, op operation, accumulatedCopySize *int64) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	valCopy, sz, err := deepCopy(val)
+	if err != nil {
+		return err
+	}
+	(*accumulatedCopySize) += int64(sz)
+	if AccumulatedCopySizeLimit > 0 && *accumulatedCopySize > AccumulatedCopySizeLimit {
+		return NewAccumulatedCopySizeError(AccumulatedCopySizeLimit, *accumulatedCopySize)
+	}
+
+	return con.add(key, valCopy)
+}
+
+// Equal indicates if 2 JSON documents have the same structural equality.
+func Equal(a, b []byte) bool {
+	ra := make(json.RawMessage, len(a))
+	copy(ra, a)
+	la := newLazyNode(&ra)
+
+	rb := make(json.RawMessage, len(b))
+	copy(rb, b)
+	lb := newLazyNode(&rb)
+
+	return la.equal(lb)
+}
+
+// DecodePatch decodes the passed JSON document as an RFC 6902 patch.
+func DecodePatch(buf []byte) (Patch, error) {
+	var p Patch
+
+	err := json.Unmarshal(buf, &p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Apply mutates a JSON document according to the patch, and returns the new
+// document.
+func (p Patch) Apply(doc []byte) ([]byte, error) {
+	return p.ApplyIndent(doc, "")
+}
+
+// ApplyIndent mutates a JSON document according to the patch, and returns the new
+// document indented.
+func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
+	var pd container
+	if doc[0] == '[' {
+		pd = &partialArray{}
+	} else {
+		pd = &partialDoc{}
+	}
+
+	err := json.Unmarshal(doc, pd)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = nil
+
+	var accumulatedCopySize int64
+
+	for _, op := range p {
+		switch op.kind() {
+		case "add":
+			err = p.add(&pd, op)
+		case "remove":
+			err = p.remove(&pd, op)
+		case "replace":
+			err = p.replace(&pd, op)
+		case "move":
+			err = p.move(&pd, op)
+		case "test":
+			err = p.test(&pd, op)
+		case "copy":
+			err = p.copy(&pd, op, &accumulatedCopySize)
+		default:
+			err = fmt.Errorf("Unexpected kind: %s", op.kind())
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if indent != "" {
+		return json.MarshalIndent(pd, "", indent)
+	}
+
+	return json.Marshal(pd)
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+
+var (
+	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+)
+
+func decodePatchKey(k string) string {
+	return rfc6901Decoder.Replace(k)
+}


### PR DESCRIPTION
With this change, the controller updates downstream resources to match spec in AkkaCluster.

If the Deployment is modified elsewhere, the Operator will put it back to match AkkaCluster spec. If the AkkaCluster spec is modified, the Operator will update all the various resources to match.

Since this operator manages a variable list of downstream resources, and has a generator to produce idealized resources based on AkkaCluster, this change introduces a generic way to determine if in-cluster resources match the ideal resources we generate. See subset.go for that functionality, with subset_test.go.

This change also introduces controller unit tests, with mocked reconciler context so we can test that resource apis were called to create / update resources.

Since this PR includes vendor/ changes, I've split things up into a few commits for ease of review.