### PR TITLE
community-operators PR comments

### DIFF
--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -2,14 +2,14 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    capabilities: Seamless Upgrades
+    capabilities: Basic Install
     categories: Application Runtime
-    certified: "false"
-    containerImage: lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest
+    certified: 'false'
+    containerImage: 'lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest'
     createdAt: 2019-05-30T00:00:00Z
     description: Run Akka Cluster applications in Kubernetes.
     repository: https://github.com/lightbend/akka-cluster-operator
-    support: Lightbend, Inc.
+    support: 'Lightbend, Inc.'
     alm-examples: |-
       [
         {
@@ -74,7 +74,7 @@ spec:
       - kind: AkkaCluster
         name: akkaclusters.app.lightbend.com
         version: v1alpha1
-        description: A demo app with cluster visualizer.
+        description: An example Akka Cluster app that provides cluster visualization.
         displayName: Akka Cluster
         resources:
           - kind: ServiceAccount
@@ -99,10 +99,19 @@ spec:
           - path: lastUpdate
           - path: managementHost
           - path: managementPort
+    required:
+      - name: ''
+        displayName: ''
+        kind: ''
+        version: ''
+        description: ''
   description: |
-    The Akka Cluster Operator runs applications built with the Akka Cluster framework.
+    The Akka Cluster Operator runs applications built with the
+    [Akka](https://doc.akka.io/docs/akka/current/guide/introduction.html)
+    framework using the AkkaCluster type.
 
-    Akka Cluster provides a fault-tolerant decentralized peer-to-peer based cluster
+    [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html) provides a
+    fault-tolerant decentralized peer-to-peer based cluster
     membership service with no single point of failure. Akka cluster allows for building
     distributed applications, where one application or service spans multiple nodes.
 
@@ -149,6 +158,7 @@ spec:
                     name: akka-cluster-operator
                     resources: {}
                 serviceAccountName: akka-cluster-operator
+      clusterPermissions: null
       permissions:
         - rules:
             - apiGroups:
@@ -219,11 +229,13 @@ spec:
     - supported: true
       type: AllNamespaces
   maturity: alpha
+  minKubeVersion: 1.11.0
   provider:
-    name: Lightbend Inc.
+    name: 'Lightbend, Inc.'
   keywords: ["Akka", "Lightbend"]
   maintainers:
-    - name: Lightbend Inc.
+    - name: 'Lightbend, Inc.'
+      email: info@lightbend.com
   links:
     - name: Intro to Akka
       url: https://doc.akka.io/docs/akka/current/guide/introduction.html

--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     certified: 'false'
     containerImage: 'lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest'
     createdAt: 2019-05-30T00:00:00Z
-    description: Run Akka Cluster applications in Kubernetes.
+    description: Run Akka Cluster applications on Kubernetes.
     repository: https://github.com/lightbend/akka-cluster-operator
     support: 'Lightbend, Inc.'
     alm-examples: |-
@@ -92,9 +92,13 @@ spec:
           - kind: ConfigMaps # operator-sdk uses this for leader election
             version: v1
         specDescriptors:
+          - description: 'How many pod instances should be members of the cluster'
+          - displayName: 'Replica Count'
           - path: replicas
           - path: template
         statusDescriptors:
+          - description: 'The status of the named Akka Cluster'
+          - displayName: 'Akka Cluster Status'
           - path: cluster
           - path: lastUpdate
           - path: managementHost
@@ -106,20 +110,23 @@ spec:
         version: ''
         description: ''
   description: |
-    The Akka Cluster Operator runs applications built with the
-    [Akka](https://doc.akka.io/docs/akka/current/guide/introduction.html)
-    framework using the AkkaCluster type.
+    The Akka Cluster Operator allows you to manage applications designed for
+    [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html).
+    Clustering with [Akka](https://doc.akka.io/docs/akka/current/guide/introduction.html) provides a
+    fault-tolerant, decentralized, peer-to-peer based cluster
+    for building stateful, distributed applications with no single point of failure.
 
-    [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html) provides a
-    fault-tolerant decentralized peer-to-peer based cluster
-    membership service with no single point of failure. Akka cluster allows for building
-    distributed applications, where one application or service spans multiple nodes.
+    Developers should use Akka Management v1.x or newer, with both Bootstrap and HTTP modules enabled.
+    When deploying using the Akka Cluster Operator, only the `management port` needs to be defined.
+    Defaults are provided by the Operator for all other required configuration.
 
-    Each AkkaCluster resource provides a Deployment spec for an application, which
-    includes a number of replicas for nodes in the Akka Cluster. The framework calls the
-    Kubernetes API to list application pods, as part of determining cluster membership, so
+    The Akka Cluster Operator provides scalabililty control and membership status information
+    for deployed applications using Akka Cluster. As part of supervising membership of running clusters,
     this Operator creates a pod-listing ServiceAccount, Role, and RoleBinding suitable for
-    each application, as well as supervises the Deployment for the application itself.
+    each application. See the project [Readme](https://github.com/lightbend/akka-cluster-operator/blob/master/README.md)
+    for more information and details.
+
+    This is an incubating project in alpha version.
   displayName: Akka Cluster Operator
   icon: # Akka icon from https://www.lightbend.com/brand
     - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NTggMjcwIj48dGl0bGU+YWtrYS1mdWxsLWNvbG9yPC90aXRsZT48ZyBpZD0iYWtrYS1mdWxsLWNvbG9yIj48cGF0aCBkPSJNMzQ5LjY0LDEwNS40NlY5My4zNGgxOS45MnY1OC40NGMwLDcuMTMsMS42Niw5Ljc5LDYuMTQsOS43OSwxLjE3LDAsMi42Ni0uMTcsNC4xNS0uMzN2MTYuMWEyOC43MSwyOC43MSwwLDAsMS05Ljc5LDEuMzNjLTQuODEsMC04LjYzLS44My0xMS42Mi0yLjY2YTE1LjQxLDE1LjQxLDAsMCwxLTYuODEtMTAuMTJDMzQ1LjgyLDE3NC42OCwzMzYuMiwxNzksMzIyLjkyLDE3OUEzOS43NCwzOS43NCwwLDAsMSwyOTMsMTY2LjM4Yy04LTguNDYtMTItMTguNzUtMTItMzEuMnM0LTIyLjc1LDEyLTMxLjA1YTM5Ljc3LDM5Ljc3LDAsMCwxLDI5Ljg4LTEyLjYxQzMzNi4zNiw5MS41MiwzNDYuNDksOTcuNDksMzQ5LjY0LDEwNS40NlptLTYsNDhhMjQuNDIsMjQuNDIsMCwwLDAsNy40Ny0xOC4yNiwyNC4zOSwyNC4zOSwwLDAsMC03LjQ3LTE4LjI2LDI0Ljc5LDI0Ljc5LDAsMCwwLTE4LjEtNy4zMSwyNCwyNCwwLDAsMC0xNy43Niw3LjMxYy00LjY1LDQuODEtNywxMS03LDE4LjI2czIuMzIsMTMuNDQsNywxOC4yNmEyNCwyNCwwLDAsMCwxNy43Niw3LjNBMjQuODIsMjQuODIsMCwwLDAsMzQzLjY3LDE1My40NFoiIGZpbGw9IiMwYjU1NjciLz48cGF0aCBkPSJNMzg4LjQ4LDE3N1Y2MS4zMWgxOS43NnY2Ny41NmwzMC44Ny0zNS41M0g0NjJsLTMyLjcsMzcuMzVMNDY1LjUxLDE3N0g0NDIuOTNsLTI2LjM5LTMzLjctOC4zLDkuM1YxNzdaIiBmaWxsPSIjMGI1NTY3Ii8+PHBhdGggZD0iTTQ3MC44MiwxNzdWNjEuMzFoMTkuNzV2NjcuNTZsMzAuODgtMzUuNTNoMjIuOTFsLTMyLjcsMzcuMzVMNTQ3Ljg0LDE3N0g1MjUuMjdsLTI2LjQtMzMuNy04LjMsOS4zVjE3N1oiIGZpbGw9IiMwYjU1NjciLz48cGF0aCBkPSJNNjA3Ljg3LDEwNS40NlY5My4zNGgxOS45MnY1OC40NGMwLDcuMTMsMS42Niw5Ljc5LDYuMTQsOS43OSwxLjE3LDAsMi42Ni0uMTcsNC4xNS0uMzN2MTYuMWEyOC43MSwyOC43MSwwLDAsMS05Ljc5LDEuMzNjLTQuODEsMC04LjYzLS44My0xMS42Mi0yLjY2YTE1LjQxLDE1LjQxLDAsMCwxLTYuODEtMTAuMTJjLTUuODEsOC43OS0xNS40MywxMy4xMS0yOC43MSwxMy4xMWEzOS43NCwzOS43NCwwLDAsMS0yOS44OC0xMi42MmMtOC04LjQ2LTEyLTE4Ljc1LTEyLTMxLjJzNC0yMi43NSwxMi0zMS4wNWEzOS43NywzOS43NywwLDAsMSwyOS44OC0xMi42MUM1OTQuNTksOTEuNTIsNjA0LjcyLDk3LjQ5LDYwNy44NywxMDUuNDZabS02LDQ4YTI0LjQyLDI0LjQyLDAsMCwwLDcuNDctMTguMjYsMjQuMzksMjQuMzksMCwwLDAtNy40Ny0xOC4yNiwyNC43OSwyNC43OSwwLDAsMC0xOC4xLTcuMzFBMjQsMjQsMCwwLDAsNTY2LDExNi45MmMtNC42NSw0LjgxLTcsMTEtNywxOC4yNnMyLjMyLDEzLjQ0LDcsMTguMjZhMjQsMjQsMCwwLDAsMTcuNzYsNy4zQTI0LjgyLDI0LjgyLDAsMCwwLDYwMS45LDE1My40NFoiIGZpbGw9IiMwYjU1NjciLz48cGF0aCBkPSJNMjMwLjI2LDIxMi44MmMzNS44OCwyOC42Nyw1OC45MS01NywxLjc0LTcyLjgyLTQ4LTEzLjI5LTk2LjMzLDkuNS0xNDQuNjYsNjIuNzRDODcuMzQsMjAyLjc0LDE3Ni42NywxNzAsMjMwLjI2LDIxMi44MloiIGZpbGw9IiMwYjU1NjciLz48cGF0aCBkPSJNODguMDgsMjAyYzM0LjQxLTM1LjY5LDkxLjY0LTc1LjUzLDE0NC45LTYwLjc1QTQ2LjA5LDQ2LjA5LDAsMCwxLDI1OS45LDE2MC42TDIwOS40OCw1OC43OGMtNy4yLTExLjQ2LTI1LjU4LTkuMTUtMzUuOTUtLjI2TDQwLjI5LDE3MC4wN2EyNy40LDI3LjQsMCwwLDAtMS41Niw0MC4xNWwwLDBhMjcuNCwyNy40LDAsMCwwLDM2LjUxLDJMODguMTQsMjAyWiIgZmlsbD0iIzE1YTljZSIvPjwvZz48L3N2Zz4=

--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     categories: Application Runtime
     certified: 'false'
     containerImage: 'lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest'

--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -92,7 +92,7 @@ spec:
           - kind: ConfigMaps # operator-sdk uses this for leader election
             version: v1
         specDescriptors:
-          - description: 'How many pod instances should be members of the cluster'
+          - description: 'The desired number of pod instances in the Akka Cluster'
           - displayName: 'Replica Count'
           - path: replicas
           - path: template

--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -2,6 +2,14 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    capabilities: Seamless Upgrades
+    categories: Application Runtime
+    certified: "false"
+    containerImage: lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest
+    createdAt: 2019-05-30T00:00:00Z
+    description: Run Akka Cluster applications in Kubernetes.
+    repository: https://github.com/lightbend/akka-cluster-operator
+    support: Lightbend, Inc.
     alm-examples: |-
       [
         {
@@ -57,14 +65,6 @@ metadata:
           }
         }
       ]
-    capabilities: Seamless Upgrades
-    categories: Application Runtime
-    description: Run Akka Cluster applications in Kubernetes.
-    containerImage: lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest
-    createdAt: 2019-05-30T00:00:00Z
-    support: Lightbend, Inc.
-    repository: https://github.com/lightbend/akka-cluster-operator
-    certified: "false"
   name: akka-cluster-operator.v0.0.1
   namespace: placeholder
 spec:
@@ -99,13 +99,12 @@ spec:
           - path: lastUpdate
           - path: managementHost
           - path: managementPort
-  # "description" is markdown for the operator's web page on operatorhub.io
   description: |
     The Akka Cluster Operator runs applications built with the Akka Cluster framework.
 
     Akka Cluster provides a fault-tolerant decentralized peer-to-peer based cluster
     membership service with no single point of failure. Akka cluster allows for building
-    distributed applications, where one application or service spans multiple nodes
+    distributed applications, where one application or service spans multiple nodes.
 
     Each AkkaCluster resource provides a Deployment spec for an application, which
     includes a number of replicas for nodes in the Akka Cluster. The framework calls the
@@ -226,14 +225,12 @@ spec:
   maintainers:
     - name: Lightbend Inc.
   links:
-    - name: Getting Started with Akka
-      url: https://www.lightbend.com/akka
     - name: Intro to Akka
       url: https://doc.akka.io/docs/akka/current/guide/introduction.html
     - name: Intro to Akka Cluster
       url: https://doc.akka.io/docs/akka/current/common/cluster.html
-    - name: Akka Cluster demo
-      url: https://github.com/dbrinegar/akka-java-cluster-openshift
+    - name: Akka Cluster demo application
+      url: https://github.com/lightbend/akka-java-cluster-openshift
     - name: Deploying a Lagom application to OpenShift
       url: https://developer.lightbend.com/guides/openshift-deployment/lagom/index.html
   version: 0.0.1


### PR DESCRIPTION
Address community-operators PR comments at CSV source.
Updates description presented on operatorhub.io
Empty `required` construct from testing w/ https://dev.operatorhub.io/bundle
Added required spec name and descriptions from catalog server.