### PR TITLE
Add version comment to achieve 100 points for go lint

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
-
+// Version akka-cluster-operator version
 var (
 	Version = "0.0.1"
 )


### PR DESCRIPTION
This  is a minor change to fix go lint reach 100 points..
Add a simple comment for exporter variable version.