### PR TITLE
Non-certified specifics from #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,5 @@ tags
 ### VisualStudioCode ###
 .vscode/*
 .history
+.metals/
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 
 ### Required OpenShift Certified Labels
 LABEL name="Akka Cluster Operator" \
-      vendor="Lightend, Inc." \
+      vendor="Lightbend, Inc." \
       version="v0.0.1" \
       release="0.0.1" \
       summary="Kubernetes Operator for Akka Cluster applications." \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,16 @@
 FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 
+### Required OpenShift Certified Labels
+LABEL name="Akka Cluster Operator" \
+      vendor="Lightend, Inc." \
+      version="v0.0.1" \
+      release="0.0.1" \
+      summary="Kubernetes Operator for Akka Cluster applications." \
+      description="Manage applications designed for [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html) and the Lightbend Platform."
+
+# Required to be in /licenses
+COPY licenses /licenses
+
 ENV OPERATOR=/usr/local/bin/akka-cluster-operator \
     USER_UID=1001 \
     USER_NAME=akka-cluster-operator

--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator.v0.0.1.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ spec:
     Developers should use Akka Management v1.x or newer, with both Bootstrap and HTTP modules enabled.
     When deploying using the Akka Cluster Operator, only the `management port` needs to be defined.
     Defaults are provided by the Operator for all other required configuration.
-    The Akka Cluster Operator provides scalabililty control and membership status information
+    The Akka Cluster Operator provides scalability control and membership status information
     for deployed applications using Akka Cluster. As part of supervising membership of running clusters,
     this Operator creates a pod-listing ServiceAccount, Role, and RoleBinding suitable for
     each application. See the project [Readme](https://github.com/lightbend/akka-cluster-operator/blob/master/README.md)


### PR DESCRIPTION
Update `Dockerfile` with labels from Certification, #20.
Applying these labels enable the single image to fulfill both editions.