### PR TITLE
Initial nil status

### DIFF
--- a/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator-certified.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.0.1/akka-cluster-operator-certified.v0.0.1.clusterserviceversion.yaml
@@ -7,9 +7,9 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Application Runtime
     certified: 'false'
-    containerImage: 'lightbend-docker-testing-registry.bintray.io/akka-cluster-operator-certified:0.0.4'
+    containerImage: 'lightbend-docker-testing-registry.bintray.io/akka-cluster-operator-certified:0.0.5'
     createdAt: '2019-06-28T15:23:00Z'
-    description: Run Akka Cluster applications on Kubernetes.
+    description: Run Akka Cluster applications on OpenShift.
     repository: https://github.com/lightbend/akka-cluster-operator
     support: 'Lightbend, Inc.'
     alm-examples: |-
@@ -157,7 +157,7 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: akka-cluster-operator
-                    image: lightbend-docker-testing-registry.bintray.io/akka-cluster-operator-certified:0.0.4
+                    image: lightbend-docker-testing-registry.bintray.io/akka-cluster-operator-certified:0.0.5
                     imagePullPolicy: Always
                     name: akka-cluster-operator
                     resources: {}

--- a/pkg/controller/akkacluster/akkacluster_controller.go
+++ b/pkg/controller/akkacluster/akkacluster_controller.go
@@ -171,6 +171,6 @@ func (r *ReconcileAkkaCluster) Reconcile(request reconcile.Request) (reconcile.R
 		// first GetStatus() and update the cluster object, then poll for future change.
 		r.statusActor.StartPolling(akkaCluster)
 	}
-
+	r.client.Status().Update(context.TODO(), nil)
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Adds `Status().Update()` before status actor becomes available.
Why? It has been suggest that the certified scorecard testing _might_ be showing a "a race condition, where the operator-sdk scorecard hits the 10s timeout before it sees anything in the CR status. If that's the case, then an initial status update of `status.cluster.members.pending` or writing a timestamp to `status.lastUpdate` (or both) would suffice as a workaround."