### PR TITLE
Add Go 111 to Github Actions Env

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,7 @@ jobs:
         DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        GO111MODULE: "on"
     - name: goreportcard
       uses: ./.github/action/curl
       with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: operator-sdk
+      env:
+        GO111MODULE: "on"
       uses: ./.github/action/operator-sdk
       with:
         args: build lightbend-docker-registry.bintray.io/lightbend/akkacluster-operator:latest
@@ -21,7 +23,6 @@ jobs:
         DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        GO111MODULE: "on"
     - name: goreportcard
       uses: ./.github/action/curl
       with:


### PR DESCRIPTION
sdk-operator v0.11+ requires Go 111 enabled in environment when using modules based projects. See failure of [master push](https://github.com/lightbend/akka-cluster-operator/commit/80e573519ae31402183047b2aa46b2e62347b248/checks).