### PR TITLE
Correct `replaces` for certified release

### DIFF
--- a/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator-certified.v0.2.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator-certified.v0.2.1.clusterserviceversion.yaml
@@ -328,5 +328,5 @@ spec:
     - name: Deploying a Lagom application to OpenShift
       url: https://developer.lightbend.com/guides/openshift-deployment/lagom/index.html
   version: 0.2.1
-  replaces: akka-cluster-operator.v0.2.0
+  replaces: akka-cluster-operator-certified.v0.2.0
 


### PR DESCRIPTION
v0.2.1 is a certified only release with no image updates.
This corrects the v0.2.1 certified CSV to replace `-certified`.