### PR TITLE
remove duplicate/hybrid status-spec Desciptor from community CSVs

### DIFF
--- a/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator.v0.2.0.clusterserviceversion.yaml
@@ -97,17 +97,6 @@ spec:
             displayName: 'Template'
             path: template
         statusDescriptors:
-          - description: The desired number of pod instances in the Akka Cluster
-            displayName: Replica Count
-            path: replicas
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:number'
-          - description: The template used to form the cluster
-            displayName: Template
-            path: template
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:text'
-        statusDescriptors:
           - description: Information on the cluster
             displayName: Cluster
             path: cluster

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator.v0.2.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator.v0.2.1.clusterserviceversion.yaml
@@ -97,17 +97,6 @@ spec:
             displayName: 'Template'
             path: template
         statusDescriptors:
-          - description: The desired number of pod instances in the Akka Cluster
-            displayName: Replica Count
-            path: replicas
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:number'
-          - description: The template used to form the cluster
-            displayName: Template
-            path: template
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:text'
-        statusDescriptors:
           - description: Information on the cluster
             displayName: Cluster
             path: cluster

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator.v0.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator.v0.2.2.clusterserviceversion.yaml
@@ -97,17 +97,6 @@ spec:
             displayName: 'Template'
             path: template
         statusDescriptors:
-          - description: The desired number of pod instances in the Akka Cluster
-            displayName: Replica Count
-            path: replicas
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:number'
-          - description: The template used to form the cluster
-            displayName: Template
-            path: template
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:text'
-        statusDescriptors:
           - description: Information on the cluster
             displayName: Cluster
             path: cluster

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator.v0.2.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator.v0.2.3.clusterserviceversion.yaml
@@ -97,17 +97,6 @@ spec:
             displayName: 'Template'
             path: template
         statusDescriptors:
-          - description: The desired number of pod instances in the Akka Cluster
-            displayName: Replica Count
-            path: replicas
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:number'
-          - description: The template used to form the cluster
-            displayName: Template
-            path: template
-            x-descriptors:
-              - 'urn:alm:descriptor:com.tectonic.ui:text'
-        statusDescriptors:
           - description: Information on the cluster
             displayName: Cluster
             path: cluster


### PR DESCRIPTION
As noted from community-operators #1256 and #1257. 
Was not in certified but in community only.
Spec was duplicated as status. IDK how I managed that. 
Cleans up the unreleased older versions, FWIW.