### PR TITLE
remove duplicated keywords in 0.2.x community CSV

### DIFF
--- a/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator-certified.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator-certified.v0.2.0.clusterserviceversion.yaml
@@ -302,10 +302,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: AkkaClusterOperator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.0/akka-cluster-operator.v0.2.0.clusterserviceversion.yaml
@@ -298,10 +298,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: akka-cluster-operator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator-certified.v0.2.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator-certified.v0.2.1.clusterserviceversion.yaml
@@ -304,10 +304,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: AkkaClusterOperator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator.v0.2.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.1/akka-cluster-operator.v0.2.1.clusterserviceversion.yaml
@@ -298,10 +298,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: akka-cluster-operator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator-certified.v0.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator-certified.v0.2.2.clusterserviceversion.yaml
@@ -304,10 +304,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: AkkaClusterOperator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator.v0.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.2/akka-cluster-operator.v0.2.2.clusterserviceversion.yaml
@@ -298,10 +298,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: akka-cluster-operator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator-certified.v0.2.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator-certified.v0.2.3.clusterserviceversion.yaml
@@ -304,10 +304,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: AkkaClusterOperator
   maturity: alpha

--- a/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator.v0.2.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/akka-cluster-operator/0.2.3/akka-cluster-operator.v0.2.3.clusterserviceversion.yaml
@@ -298,10 +298,6 @@ spec:
       type: MultiNamespace
     - supported: true
       type: AllNamespaces
-  keywords:
-    - Akka
-    - Akka Cluster
-    - Lightbend
   labels:
     Name: akka-cluster-operator
   maturity: alpha


### PR DESCRIPTION
`keywords` was duplicated in community edition. Unsure how preview didn't catch this earlier. 